### PR TITLE
Update

### DIFF
--- a/API/include/Utils.class.php
+++ b/API/include/Utils.class.php
@@ -3,7 +3,7 @@
 class Utils
 {
 	static private $API_BASE_URL = "https://api.thegamesdb.net";
-	static public $BOXART_BASE_URL = "https://thegamesdb.net/banner/";
+	static public $BOXART_BASE_URL = "http://thegamesdb.net/banners/";
 
 	static private $_statusMSG = array(
 		200 => "Success",

--- a/API/include/Utils.class.php
+++ b/API/include/Utils.class.php
@@ -4,6 +4,7 @@ class Utils
 {
 	static private $API_BASE_URL = "https://api.thegamesdb.net";
 	static public $BOXART_BASE_URL = "http://thegamesdb.net/banners/";
+	static public $BOXART_CACHE_BASE_URL = "http://thegamesdb.net/banners/_cache/";
 
 	static private $_statusMSG = array(
 		200 => "Success",

--- a/API/include/Utils.class.php
+++ b/API/include/Utils.class.php
@@ -32,7 +32,7 @@ class Utils
 		{
 			return $_REQUEST['page'];
 		}
-		return 0;
+		return 1;
 	}
 	
 	static function parseRequestOptions()
@@ -67,7 +67,7 @@ class Utils
 	{
 		$GET = $_GET;
 		$ret['previous'] = NULL;
-		if($current_page > 0)
+		if($current_page > 1)
 		{
 			$GET['page'] = $current_page-1;
 			$ret['previous'] = Utils::$API_BASE_URL . $_SERVER['REDIRECT_URL'] . "?" . http_build_query($GET,'','&');

--- a/API/include/Utils.class.php
+++ b/API/include/Utils.class.php
@@ -69,17 +69,17 @@ class Utils
 		if($current_page > 0)
 		{
 			$GET['page'] = $current_page-1;
-			$ret['previous'] = Utils::$API_BASE_URL . "/" . $_SERVER['SCRIPT_NAME']. $_SERVER['PATH_INFO'] . "?" . http_build_query($GET,'','&');
+			$ret['previous'] = Utils::$API_BASE_URL . $_SERVER['REDIRECT_URL'] . "?" . http_build_query($GET,'','&');
 		}
 	
 		$GET['page'] = $current_page;
-		$ret['current'] = Utils::$API_BASE_URL . "/" . $_SERVER['SCRIPT_NAME']. $_SERVER['PATH_INFO'] . "?" . http_build_query($GET,'','&');
+		$ret['current'] = Utils::$API_BASE_URL . $_SERVER['REDIRECT_URL'] . "?" . http_build_query($GET,'','&');
 	
 		$ret['next'] = NULL;
 		if($has_next_page)
 		{
 			$GET['page'] = $current_page+1;
-			$ret['next'] = Utils::$API_BASE_URL . "/" . $_SERVER['SCRIPT_NAME'] . $_SERVER['PATH_INFO'] . "?" . http_build_query($GET,'','&');
+			$ret['next'] = Utils::$API_BASE_URL  . $_SERVER['REDIRECT_URL'] . "?" . http_build_query($GET,'','&');
 		}
 		return $ret;
 	}

--- a/API/include/middleware.php
+++ b/API/include/middleware.php
@@ -6,7 +6,7 @@ class AuthMiddleware
 {
 	public function __invoke($request, $response, $next)
 	{
-		if($_SERVER['PATH_INFO'] == '/')
+		if(!isset($_SERVER['REDIRECT_URL']))
 		{
 			return $next($request, $response);
 		}

--- a/API/include/routes.php
+++ b/API/include/routes.php
@@ -181,22 +181,24 @@ $app->group('/Games', function()
 			return $response->withJson($JSON_Response, $JSON_Response['code']);
 		}
 
-		$limit = 20;
+		$limit = 30;
 		$page = Utils::getPage();
 		$offset = $page * $limit;
 		$options = Utils::parseRequestOptions();
+		$filters = isset($_REQUEST['filter']) ? explode("," , $_REQUEST['filter']) : 'ALL';
 
 		$API = TGDB::getInstance();
-		// TODO: consider return count, as each cover has multiple  result thus can hit 20 really quick
-		// but maybe this is should remain the default choice?
-		$list = $API->GetGameBoxartByID($GameIDs, $offset, $limit+1, 'ALL');
+		$list = $API->GetGameBoxartByID($GameIDs, $offset, $limit+1, $filters);
 
-		if($has_next_page = count($list) > $limit)
-			unset($list[$limit]);
+		$count = 0;
+		foreach($list as $boxarts)
+		{
+			$count += count($boxarts);
+		}
+		$has_next_page = $count > $limit;
 
 		$JSON_Response = Utils::getStatus(200);
 		$JSON_Response['data'] = array("count" => count($list), 'base_url' => Utils::$BOXART_BASE_URL, "boxart" => $list);
-
 		$JSON_Response['pages'] = Utils::getJsonPageUrl($page, $has_next_page);
 
 		return $response->withJson($JSON_Response);

--- a/API/include/routes.php
+++ b/API/include/routes.php
@@ -36,7 +36,7 @@ $app->group('/Games', function()
 
 		$limit = 20;
 		$page = Utils::getPage();
-		$offset = $page * $limit;
+		$offset = ($page - 1) * $limit;
 		$options = Utils::parseRequestOptions();
 		$fields = Utils::parseRequestedFields();
 
@@ -89,7 +89,7 @@ $app->group('/Games', function()
 
 		$limit = 20;
 		$page = Utils::getPage();
-		$offset = $page * $limit;
+		$offset = ($page - 1) * $limit;
 		$options = Utils::parseRequestOptions();
 		$fields = Utils::parseRequestedFields();
 
@@ -137,7 +137,7 @@ $app->group('/Games', function()
 
 		$limit = 20;
 		$page = Utils::getPage();
-		$offset = $page * $limit;
+		$offset = ($page - 1) * $limit;
 		$options = Utils::parseRequestOptions();
 		$fields = Utils::parseRequestedFields();
 
@@ -183,7 +183,7 @@ $app->group('/Games', function()
 
 		$limit = 30;
 		$page = Utils::getPage();
-		$offset = $page * $limit;
+		$offset = ($page - 1) * $limit;
 		$options = Utils::parseRequestOptions();
 		$filters = isset($_REQUEST['filter']) ? explode("," , $_REQUEST['filter']) : 'ALL';
 
@@ -214,7 +214,7 @@ $app->group('/Games', function()
 
 		$limit = 20;
 		$page = Utils::getPage();
-		$offset = $page * $limit;
+		$offset = ($page - 1) * $limit;
 		$options = Utils::parseRequestOptions();
 		$fields = Utils::parseRequestedFields();
 

--- a/include/TGDB.API.php
+++ b/include/TGDB.API.php
@@ -198,7 +198,7 @@ class TGDB
 		}
 
 		$qry = "Select keyvalue as games_id, keytype as type, filename, resolution FROM banners WHERE keyvalue IN ($GameIDs) ";
-		switch('boxart')
+		switch($filter)
 		{
 			case 'boxart':
 				$qry .=" AND keytype='boxart' ";

--- a/include/TGDB.API.php
+++ b/include/TGDB.API.php
@@ -173,6 +173,39 @@ class TGDB
 		}
 	}
 
+	function GetGamesByLatestUpdatedDate($minutes, $offset = 0, $limit = 20, $fields = array())
+	{
+		$qry = "Select id, GameTitle, Developer, ReleaseDate, Platform ";
+
+		if(!empty($fields))
+		{
+			foreach($fields as $key => $enabled)
+			{
+				if($enabled && $this->is_valid_games_col($key))
+				{
+					$qry .= ", $key ";
+				}
+			}
+		}
+
+		$qry .= " FROM games WHERE lastupdatedRevised > DATE_ADD(CURRENT_TIMESTAMP(), INTERVAL -:minutes MINUTE) ORDER BY lastupdatedRevised DESC LIMIT :limit OFFSET :offset";
+
+		$dbh = $this->database->dbh;
+		$sth = $dbh->prepare($qry);
+
+		$sth->bindValue(':minutes', $minutes, PDO::PARAM_INT);
+		$sth->bindValue(':offset', $offset, PDO::PARAM_INT);
+		$sth->bindValue(':limit', $limit, PDO::PARAM_INT);
+
+		if($sth->execute())
+		{
+			$res = $sth->fetchAll(PDO::FETCH_OBJ);
+			return $res;
+		}
+
+		return array();
+	}
+
 	//TODO:filter return type
 	function GetGameBoxartByID($IDs = 0, $offset = 0, $limit = 20, $filter = 'boxart')
 	{

--- a/include/TGDB.API.php
+++ b/include/TGDB.API.php
@@ -23,13 +23,13 @@ class TGDB
 		return $instance;
 	}
 
-	function GetGameListByPlatform($IDs = 0, $offset = 0, $limit = 20, $options = array())
+	function GetGameListByPlatform($IDs = 0, $offset = 0, $limit = 20, $fields = array())
 	{
 		$qry = "Select id, GameTitle, Developer, ReleaseDate, Platform ";
 
-		if(!empty($options))
+		if(!empty($fields))
 		{
-			foreach($options as $key => $enabled)
+			foreach($fields as $key => $enabled)
 			{
 				if($enabled && $this->is_valid_games_col($key))
 				{
@@ -76,7 +76,7 @@ class TGDB
 		}
 	}
 
-	function GetGameByID($IDs, $offset = 0, $limit = 20, $options = array())
+	function GetGameByID($IDs, $offset = 0, $limit = 20, $fields = array())
 	{
 		$GameIDs = array();
 		if(is_array($IDs))
@@ -101,9 +101,9 @@ class TGDB
 
 		$qry = "Select id, GameTitle, Developer, ReleaseDate, Platform ";
 
-		if(!empty($options))
+		if(!empty($fields))
 		{
-			foreach($options as $key => $enabled)
+			foreach($fields as $key => $enabled)
 			{
 				if($enabled && $this->is_valid_games_col($key))
 				{
@@ -129,15 +129,15 @@ class TGDB
 		return array();
 	}
 
-	function SearchGamesByName($searchTerm, $offset = 0, $limit = 20, $options = array())
+	function SearchGamesByName($searchTerm, $offset = 0, $limit = 20, $fields = array())
 	{
 		$dbh = $this->database->dbh;
 
 		$qry = "Select id, GameTitle, Developer, ReleaseDate, Platform ";
 
-		if(!empty($options))
+		if(!empty($fields))
 		{
-			foreach($options as $key => $enabled)
+			foreach($fields as $key => $enabled)
 			{
 				if($enabled && $this->is_valid_games_col($key))
 				{
@@ -218,15 +218,15 @@ class TGDB
 		}
 	}
 
-	function GetPlatformsList($options = array())
+	function GetPlatformsList($fields = array())
 	{
 		$qry = "Select id, name, alias FROM platforms;";
 
 		$dbh = $this->database->dbh;
-		if(!empty($options))
+		if(!empty($fields))
 		{
 			$qry = "Select id, name, alias";
-			foreach($options as $key => $enabled)
+			foreach($fields as $key => $enabled)
 			{
 				if($enabled && $this->is_valid_platform_col($key))
 				{
@@ -245,7 +245,7 @@ class TGDB
 		}
 	}
 
-	function GetPlatforms($IDs, $options = array())
+	function GetPlatforms($IDs, $fields = array())
 	{
 		$PlatformIDs;
 		if(is_array($IDs))
@@ -271,10 +271,10 @@ class TGDB
 		$qry = "Select id, name, alias FROM platforms";
 
 		$dbh = $this->database->dbh;
-		if(!empty($options))
+		if(!empty($fields))
 		{
 			$qry = "Select id, name, alias";
-			foreach($options as $key => $enabled)
+			foreach($fields as $key => $enabled)
 			{
 				if($enabled && $this->is_valid_platform_col($key))
 				{
@@ -294,16 +294,16 @@ class TGDB
 		}
 	}
 
-	function SearchPlatformByName($searchTerm, $options = array())
+	function SearchPlatformByName($searchTerm, $fields = array())
 	{
 		$dbh = $this->database->dbh;
 
 		$qry = "Select id, name, alias";
 
 		$dbh = $this->database->dbh;
-		if(!empty($options))
+		if(!empty($fields))
 		{
-			foreach($options as $key => $enabled)
+			foreach($fields as $key => $enabled)
 			{
 				if($enabled && $this->is_valid_platform_col($key))
 				{

--- a/include/TGDB.API.php
+++ b/include/TGDB.API.php
@@ -197,7 +197,7 @@ class TGDB
 			return array();
 		}
 
-		$qry = "Select keyvalue as games_id, keytype as type, filename, resolution FROM banners WHERE keyvalue IN ($GameIDs) ";
+		$qry = "Select keyvalue as games_id, keytype as type, side, filename, resolution FROM banners WHERE keyvalue IN ($GameIDs) ";
 		switch($filter)
 		{
 			case 'boxart':

--- a/include/TGDB.API.php
+++ b/include/TGDB.API.php
@@ -154,11 +154,13 @@ class TGDB
 			}
 		}
 
-		$qry .= " FROM games WHERE GameTitle LIKE :name OR GameTitle=:name2 OR soundex(GameTitle) LIKE soundex(:name3)
-		GROUP BY id ORDER BY CASE WHEN GameTitle like :name4 THEN 0
-		WHEN GameTitle like :name5 THEN 1
-		WHEN GameTitle like :name6 THEN 2
-		ELSE 3
+		$qry .= " FROM games WHERE GameTitle LIKE :name OR GameTitle=:name2 OR soundex(GameTitle) LIKE soundex(:name3) OR soundex(GameTitle) LIKE soundex(:name4)
+		GROUP BY id ORDER BY CASE
+		WHEN GameTitle like :name5 THEN 4
+		WHEN GameTitle like :name6 THEN 3
+		WHEN GameTitle like :name7 THEN 0
+		WHEN GameTitle like :name8 THEN 1
+		ELSE 5
 		END, GameTitle LIMIT :limit OFFSET :offset";
 
 		$sth = $dbh->prepare($qry);
@@ -167,8 +169,11 @@ class TGDB
 		$sth->bindValue(':name2', $searchTerm);
 		$sth->bindValue(':name3', "$searchTerm%");
 		$sth->bindValue(':name4', "% %$searchTerm% %");
+
 		$sth->bindValue(':name5', "%$searchTerm");
 		$sth->bindValue(':name6', $searchTerm);
+		$sth->bindValue(':name7', "$searchTerm%");
+		$sth->bindValue(':name8', "% %$searchTerm% %");
 
 
 		$sth->bindValue(':offset', $offset, PDO::PARAM_INT);
@@ -353,11 +358,13 @@ class TGDB
 			}
 		}
 
-		$qry .= " FROM platforms WHERE name LIKE :name OR name=:name2 OR soundex(name) LIKE soundex(:name3)
-		GROUP BY id ORDER BY CASE WHEN name like :name4 THEN 0
-		WHEN name like :name5 THEN 1
-		WHEN name like :name6 THEN 2
-		ELSE 3
+		$qry .= " FROM platforms WHERE name LIKE :name OR name=:name2 OR soundex(name) LIKE soundex(:name3) OR soundex(name) LIKE soundex(:name4)
+		GROUP BY id ORDER BY CASE
+		WHEN name like :name5 THEN 4
+		WHEN name like :name6 THEN 3
+		WHEN name like :name7 THEN 0
+		WHEN name like :name8 THEN 1
+		ELSE 5
 		END, name";
 
 		$sth = $dbh->prepare($qry);
@@ -366,8 +373,11 @@ class TGDB
 		$sth->bindValue(':name2', $searchTerm);
 		$sth->bindValue(':name3', "$searchTerm%");
 		$sth->bindValue(':name4', "% %$searchTerm% %");
+
 		$sth->bindValue(':name5', "%$searchTerm");
 		$sth->bindValue(':name6', $searchTerm);
+		$sth->bindValue(':name7', "$searchTerm%");
+		$sth->bindValue(':name8', "% %$searchTerm% %");
 
 		if($sth->execute())
 		{

--- a/include/TGDB.API.php
+++ b/include/TGDB.API.php
@@ -156,11 +156,11 @@ class TGDB
 
 		$qry .= " FROM games WHERE GameTitle LIKE :name OR GameTitle=:name2 OR soundex(GameTitle) LIKE soundex(:name3) OR soundex(GameTitle) LIKE soundex(:name4)
 		GROUP BY id ORDER BY CASE
-		WHEN GameTitle like :name5 THEN 4
-		WHEN GameTitle like :name6 THEN 3
-		WHEN GameTitle like :name7 THEN 0
-		WHEN GameTitle like :name8 THEN 1
-		ELSE 5
+		WHEN GameTitle like :name5 THEN 3
+		WHEN GameTitle like :name6 THEN 0
+		WHEN GameTitle like :name7 THEN 1
+		WHEN GameTitle like :name8 THEN 2
+		ELSE 4
 		END, GameTitle LIMIT :limit OFFSET :offset";
 
 		$sth = $dbh->prepare($qry);
@@ -397,11 +397,11 @@ class TGDB
 
 		$qry .= " FROM platforms WHERE name LIKE :name OR name=:name2 OR soundex(name) LIKE soundex(:name3) OR soundex(name) LIKE soundex(:name4)
 		GROUP BY id ORDER BY CASE
-		WHEN name like :name5 THEN 4
-		WHEN name like :name6 THEN 3
-		WHEN name like :name7 THEN 0
-		WHEN name like :name8 THEN 1
-		ELSE 5
+		WHEN name like :name5 THEN 3
+		WHEN name like :name6 THEN 0
+		WHEN name like :name7 THEN 1
+		WHEN name like :name8 THEN 2
+		ELSE 4
 		END, name";
 
 		$sth = $dbh->prepare($qry);

--- a/include/TGDB.API.php
+++ b/include/TGDB.API.php
@@ -266,12 +266,11 @@ class TGDB
 
 	function GetPlatformsList($fields = array())
 	{
-		$qry = "Select id, name, alias FROM platforms;";
+		$qry = "Select id, name, alias ";
 
 		$dbh = $this->database->dbh;
 		if(!empty($fields))
 		{
-			$qry = "Select id, name, alias";
 			foreach($fields as $key => $enabled)
 			{
 				if($enabled && $this->is_valid_platform_col($key))
@@ -279,9 +278,10 @@ class TGDB
 					$qry .= ", $key ";
 				}
 			}
-			$qry .= " FROM platforms;";
 		}
-		
+
+		$qry .= " FROM platforms;";
+
 		$sth = $dbh->prepare($qry);
 
 		if($sth->execute())
@@ -314,12 +314,11 @@ class TGDB
 			return array();
 		}
 
-		$qry = "Select id, name, alias FROM platforms";
+		$qry = "Select id as n, id, name, alias ";
 
 		$dbh = $this->database->dbh;
 		if(!empty($fields))
 		{
-			$qry = "Select id, name, alias";
 			foreach($fields as $key => $enabled)
 			{
 				if($enabled && $this->is_valid_platform_col($key))
@@ -327,9 +326,8 @@ class TGDB
 					$qry .= ", $key ";
 				}
 			}
-			$qry .= " FROM platforms ";
 		}
-		$qry .= " Where id IN ($PlatformIDs);";
+		$qry .= " FROM platforms Where id IN ($PlatformIDs);";
 
 		$sth = $dbh->prepare($qry);
 

--- a/include/TGDB.API.php
+++ b/include/TGDB.API.php
@@ -319,7 +319,7 @@ class TGDB
 			}
 		}
 
-		$qry .= " FROM platforms;";
+		$qry .= " FROM platforms ORDER BY name;";
 
 		$sth = $dbh->prepare($qry);
 
@@ -366,7 +366,7 @@ class TGDB
 				}
 			}
 		}
-		$qry .= " FROM platforms Where id IN ($PlatformIDs);";
+		$qry .= " FROM platforms Where id IN ($PlatformIDs) ORDER BY name;";
 
 		$sth = $dbh->prepare($qry);
 

--- a/include/TGDB.API.php
+++ b/include/TGDB.API.php
@@ -240,7 +240,7 @@ class TGDB
 
 		if($sth->execute())
 		{
-			$res = $sth->fetchAll(PDO::FETCH_OBJ | PDO::FETCH_GROUP);
+			$res = $sth->fetchAll(PDO::FETCH_OBJ | PDO::FETCH_GROUP | PDO::FETCH_UNIQUE);
 			return $res;
 		}
 	}
@@ -289,7 +289,7 @@ class TGDB
 
 		if($sth->execute())
 		{
-			$res = $sth->fetchAll(PDO::FETCH_OBJ | PDO::FETCH_GROUP);
+			$res = $sth->fetchAll(PDO::FETCH_OBJ | PDO::FETCH_GROUP | PDO::FETCH_UNIQUE);
 			return $res;
 		}
 	}

--- a/include/TGDB.API.php
+++ b/include/TGDB.API.php
@@ -219,8 +219,35 @@ class TGDB
 		return array();
 	}
 
-	//TODO:filter return type
-	function GetGameBoxartByID($IDs = 0, $offset = 0, $limit = 20, $filter = 'boxart')
+	private function CreateBoxartFilterQuery($filter, &$is_filter)
+	{
+		$qry = "";
+		switch($filter)
+		{
+			case 'fanart':
+			case 'series':
+			case 'boxart':
+			case 'screenshot':
+			case 'platform-banner':
+			case 'platform-fanart':
+			case 'platform-boxart':
+			case 'clearlogo':
+				if(!$is_filter)
+				{
+					$qry .=" AND (";
+					$is_filter = true;
+
+				}
+				else
+				{
+					$qry .=" OR ";
+				}
+				$qry .=" keytype = '$filter' ";
+		}
+		return $qry;
+	}
+
+	function GetGameBoxartByID($IDs = 0, $offset = 0, $limit = 20, $filters = 'boxart')
 	{
 		$GameIDs;
 		if(is_array($IDs))
@@ -244,10 +271,22 @@ class TGDB
 		}
 
 		$qry = "Select keyvalue as games_id, keytype as type, side, filename, resolution FROM banners WHERE keyvalue IN ($GameIDs) ";
-		switch($filter)
+		$is_filter = false;
+		if(is_array($filters))
 		{
-			case 'boxart':
-				$qry .=" AND keytype='boxart' ";
+			foreach($filters as $filter)
+			{
+				$qry .= $this->CreateBoxartFilterQuery($filter, $is_filter);
+			}
+		}
+		else
+		{
+			$qry .= $this->CreateBoxartFilterQuery($filters, $is_filter);
+		}
+
+		if($is_filter)
+		{
+			$qry .=" )";
 		}
 		$qry .= " LIMIT :limit OFFSET :offset;";
 

--- a/include/TGDB.API.php
+++ b/include/TGDB.API.php
@@ -23,7 +23,7 @@ class TGDB
 		return $instance;
 	}
 
-	function GetGameListByPlatform($IDs = 0, $offset = 0, $limit = 20, $fields = array())
+	function GetGameListByPlatform($IDs = 0, $offset = 0, $limit = 20, $fields = array(), $OrderBy = '', $ASCDESC = 'ASC')
 	{
 		$qry = "Select id, GameTitle, Developer, ReleaseDate, Platform ";
 
@@ -61,7 +61,15 @@ class TGDB
 		{
 			$qry .= "WHERE Platform IN ($PlatformIDs) ";
 		}
-		$qry .= "LIMIT :limit OFFSET :offset;";
+		if(!empty($OrderBy) && $this->is_valid_games_col($OrderBy))
+		{
+			if($ASCDESC != 'ASC' && $ASCDESC != 'DESC')
+			{
+				$ASCDESC == 'ASC';
+			}
+			$qry .= " ORDER BY $OrderBy $ASCDESC ";
+		}
+		$qry .= " LIMIT :limit OFFSET :offset;";
 
 		$dbh = $this->database->dbh;
 		$sth = $dbh->prepare($qry);


### PR DESCRIPTION
This PR is mainly cleanup, with few additions such as `/Updates` API endpoint, and `/Games/Boxart`API endpoint accepting filter parameter (e.g. `/Games/Boxart?GameID=12,13,14&filter=boxart,fanart`)

Note: the `/Updates` API endpoint will not work as is, but requests a new table field, currently named `lastupdatedRevised` of type `timestamp` ideally and in time we'd drop `lastupdated` altogether. while the current method works I find `timestamp` to look visually clearer.