### PR TITLE
Show region in search

### DIFF
--- a/website/search.php
+++ b/website/search.php
@@ -101,6 +101,11 @@ $Header->setTitle("TGDB - Search");
 							</div>
 							<div class="card-footer bg-secondary" style="text-align:center;">
 								<p><?= $Game->game_title ?></p>
+								<?php if ($Game->region_id > 0):
+									$region = $API->GetGameRegion($Game->region_id); 
+								?>
+								<p><?= $region->name ?></p>
+								<?php endif; ?>
 								<p><?= $Game->release_date ?></p>
 								<p class="text-muted"><?= $PlatformList[$Game->platform]->name ?></p>
 							</div>


### PR DESCRIPTION
I was thinking of ways to improve search results and avoid duplicates or being able to differentiate entries that looks the same. And since the introduction of regions, it is impossible from the search to easily know if a game which look the same is different. 

I know the cover, will, for example have an ESRB logo for NTSC or PEGI for PAL, but it is not that easy to differentiate and understand. 

So I added the game region in the search result, to be able to instantly differentiate them.